### PR TITLE
slack notification cleanup for apps

### DIFF
--- a/0-bootstrap/argocd/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/argocd/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
@@ -7,6 +7,7 @@ spec:
   sourceRepos:
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops.git
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops-apps.git
+  - https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
   destinations:
   - namespace: ci
     server: https://kubernetes.default.svc
@@ -15,6 +16,10 @@ spec:
   - namespace: staging
     server: https://kubernetes.default.svc
   - namespace: prod
+    server: https://kubernetes.default.svc
+  - namespace: slack-notifications
+    server: https://kubernetes.default.svc
+  - namespace: openshift-pipelines
     server: https://kubernetes.default.svc
   roles:
   # A role which provides read-only access to all applications in the project

--- a/0-bootstrap/argocd/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
+++ b/0-bootstrap/argocd/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
@@ -8,9 +8,9 @@ spec:
   destination:
     namespace: openshift-pipelines
     server: https://kubernetes.default.svc
-  project: infra
+  project: applications
   source:
-    path: shared/config/openshift-pipelines/configmap/openshift-pipelines-config
+    path: shared/config/openshift-pipelines/configmap
     repoURL: https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
     targetRevision: master
   syncPolicy:

--- a/0-bootstrap/argocd/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
+++ b/0-bootstrap/argocd/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
@@ -7,6 +7,7 @@ spec:
   sourceRepos:
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops.git
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops-apps.git
+  - https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
   destinations:
   - namespace: ci
     server: https://kubernetes.default.svc
@@ -15,6 +16,10 @@ spec:
   - namespace: staging
     server: https://kubernetes.default.svc
   - namespace: prod
+    server: https://kubernetes.default.svc
+  - namespace: slack-notifications
+    server: https://kubernetes.default.svc
+  - namespace: openshift-pipelines
     server: https://kubernetes.default.svc
   roles:
   # A role which provides read-only access to all applications in the project

--- a/0-bootstrap/argocd/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/argocd/shared/config/openshift-pipelines/cofigmap/openshift-pipelines-config.yaml
+++ b/0-bootstrap/argocd/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/argocd/shared/config/openshift-pipelines/cofigmap/openshift-pipelines-config.yaml
@@ -8,9 +8,9 @@ spec:
   destination:
     namespace: openshift-pipelines
     server: https://kubernetes.default.svc
-  project: infra
+  project: applications
   source:
-    path: shared/config/openshift-pipelines/configmap/openshift-pipelines-config
+    path: shared/config/openshift-pipelines/configmap
     repoURL: https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
     targetRevision: master
   syncPolicy:

--- a/0-bootstrap/argocd/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
+++ b/0-bootstrap/argocd/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
@@ -7,6 +7,7 @@ spec:
   sourceRepos:
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops.git
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops-apps.git
+  - https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
   destinations:
   - namespace: ci
     server: https://kubernetes.default.svc
@@ -15,6 +16,10 @@ spec:
   - namespace: staging
     server: https://kubernetes.default.svc
   - namespace: prod
+    server: https://kubernetes.default.svc
+  - namespace: slack-notifications
+    server: https://kubernetes.default.svc
+  - namespace: openshift-pipelines
     server: https://kubernetes.default.svc
   roles:
   # A role which provides read-only access to all applications in the project

--- a/0-bootstrap/argocd/others/3-multi-cluster/cluster-1-cicd/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
+++ b/0-bootstrap/argocd/others/3-multi-cluster/cluster-1-cicd/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
@@ -8,9 +8,9 @@ spec:
   destination:
     namespace: openshift-pipelines
     server: https://kubernetes.default.svc
-  project: infra
+  project: applications
   source:
-    path: shared/config/openshift-pipelines/configmap/openshift-pipelines-config
+    path: shared/config/openshift-pipelines/configmap
     repoURL: https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
     targetRevision: master
   syncPolicy:

--- a/0-bootstrap/argocd/single-cluster/3-apps/3-apps.yaml
+++ b/0-bootstrap/argocd/single-cluster/3-apps/3-apps.yaml
@@ -7,6 +7,7 @@ spec:
   sourceRepos:
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops.git
   - https://github.com/cloud-native-toolkit/multi-tenancy-gitops-apps.git
+  - https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
   destinations:
   - namespace: ci
     server: https://kubernetes.default.svc
@@ -17,6 +18,8 @@ spec:
   - namespace: prod
     server: https://kubernetes.default.svc
   - namespace: slack-notifications
+    server: https://kubernetes.default.svc
+  - namespace: openshift-pipelines
     server: https://kubernetes.default.svc
   roles:
   # A role which provides read-only access to all applications in the project

--- a/0-bootstrap/argocd/single-cluster/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
+++ b/0-bootstrap/argocd/single-cluster/3-apps/argocd/shared/config/openshift-pipelines/configmap/openshift-pipelines-config.yaml
@@ -8,9 +8,9 @@ spec:
   destination:
     namespace: openshift-pipelines
     server: https://kubernetes.default.svc
-  project: infra
+  project: applications
   source:
-    path: shared/config/openshift-pipelines/configmap/openshift-pipelines-config
+    path: shared/config/openshift-pipelines/configmap
     repoURL: https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-apps.git
     targetRevision: master
   syncPolicy:


### PR DESCRIPTION
For the Apps I had to fix the following:

- In 3-apps.yaml
    - Add the cloud-native-toolkit-demos/multi-tenancy-gitops-apps sourceRepo 
    - Add slack-notification and openshift-pipelines destinations
- in openshift-pipelines-config-yaml
    - Change ArgoCD project type to be `applications`
    - fix source.path 

Signed-off-by: Larry Steck <lsteck@us.ibm.com>