### PR TITLE
add .gitignore file to stop secrets being pushed to GitHub GitOps repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*credentials-secret.yaml


### PR DESCRIPTION
Signed-off-by: Anthony O'Dowd <a_o-dowd@uk.ibm.com>

Added a .gitignore file to stop secrets files being pushed to user's GitOps repo on GitHub after discussion with @osowski 