### PR TITLE
Revert "deploying soapserver from apps repo argo app instead top level gitops repo"

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/single-cluster/3-apps/kustomization.yaml
+++ b/0-bootstrap/single-cluster/3-apps/kustomization.yaml
@@ -19,6 +19,8 @@ resources:
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
 
+#- argocd/soapserver/soapserver.yaml
+
 patches:
 - target:
     group: argoproj.io


### PR DESCRIPTION
Reverts cloud-native-toolkit/multi-tenancy-gitops#96

Going to put soapserver back to apps layer, since it feels more like part of ACE example and not a general operator or operator instance 