### PR TITLE
Add soapserver for ACE example bom

### DIFF
--- a/scripts/bom/ace/3-apps/kustomization.yaml
+++ b/scripts/bom/ace/3-apps/kustomization.yaml
@@ -4,6 +4,9 @@ resources:
 - argocd/ace/stage.yaml
 - argocd/ace/prod.yaml
 
+# Required for ACE Example
+- argocd/soapserver/soapserver.yaml
+
 #- argocd/mq/cicd.yaml
 #- argocd/mq/dev.yaml
 #- argocd/mq/stage.yaml
@@ -18,8 +21,6 @@ resources:
 #- argocd/bookinfo/dev.yaml
 #- argocd/bookinfo/stage.yaml
 #- argocd/bookinfo/prod.yaml
-
-#- argocd/soapserver/soapserver.yaml
 
 patches:
 - target:


### PR DESCRIPTION
when using https://github.com/cloud-native-toolkit-demos/multi-tenancy-gitops-ace we need to enable soapserver
