### PR TITLE
adding infrastructure golden topology provisioning logic

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -32,4 +32,4 @@ spec:
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created
-          text: "IBM App Connect (ACE)"
+          text: "Cluster Description"

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/0-bootstrap/single-cluster/1-infra/1-infra.yaml
+++ b/0-bootstrap/single-cluster/1-infra/1-infra.yaml
@@ -30,6 +30,14 @@ spec:
     server: https://kubernetes.default.svc
   - namespace: openshift-gitops
     server: https://kubernetes.default.svc
+  - namespace: openshift-machine-api
+    server: https://kubernetes.default.svc
+  - namespace: openshift-storage
+    server: https://kubernetes.default.svc
+  - namespace: openshift-monitoring
+    server: https://kubernetes.default.svc
+  - namespace: openshift-cluster-node-tuning-operator 
+    server: https://kubernetes.default.svc
   clusterResourceWhitelist:
   - group: ""
     kind: Namespace
@@ -41,6 +49,16 @@ spec:
     kind: ConsoleNotification
   - group: "console.openshift.io"
     kind: ConsoleLink
+  - group: "machine.openshift.io"
+    kind: MachineSet
+  - group: "machineconfiguration.openshift.io"
+    kind: MachineConfigPool
+  - group: "machineconfiguration.openshift.io"
+    kind: ContainerRuntimeConfig
+  - group: "tuned.openshift.io"
+    kind: Tuned
+  - group: "batch"
+    kind: Job
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only

--- a/0-bootstrap/single-cluster/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/infraconfig.yaml
@@ -19,11 +19,11 @@ spec:
       values: |
         refarch-infraconfig:
           cloudProvider:
-            name: "aws" # set to aws or vsphere,
-            managed: "false" # set to true for ARO or ROSA
+            name: "${PLATFORM}" # set to aws or vsphere,
+            managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
             namespace: openshift-gitops
-            serviceAccount: argocd-cluster-argocd-application-controller
+            serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
             replicas: 2

--- a/0-bootstrap/single-cluster/1-infra/argocd/machinesets.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/machinesets.yaml
@@ -18,32 +18,22 @@ spec:
     helm:
       values: |
         refarch-machinesets:
-          infrastructureId: "rosa-east-2-zv89m"
+          infrastructureId: "${INFRASTRUCTURE_ID}"
+          # cloudProvider.name set to aws, azure or vsphere
           cloudProvider:
-            name: "aws" # set to aws, azure or vsphere
-            managed: false
-          aws:
-            region: us-east-1
-            zones:
-            - us-east-1a
-            - us-east-1b
-            - us-east-1c
-            image: ami-01ea0772949cb189a
-            infraNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
-            storageNodes:
-              nodeCount: 1
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.4xlarge
-            cloudpakNodes:
-              nodeCount: 0
-              volumeSize: 120
-              volumeType: gp2
-              instanceType: m5.xlarge
+            name: "${PLATFORM}" 
+            managed: ${MANAGED}
+          # only for "aws" or "azure" maybe "gcp"
+          cloud:
+            region: ${REGION}
+            image: ${IMAGE_NAME}
+          # only for "vsphere" - ignored for other
+          vsphere:
+            networkName: ${VS_NETWORK}
+            datacenter: ${VS_DATACENTER}
+            datastore: ${VS_DATASTORE} 
+            cluster: ${VS_CLUSTER} 
+            server: ${VS_SERVER} 
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/single-cluster/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/storage.yaml
@@ -18,10 +18,9 @@ spec:
     helm:
       values: |
         ocs-operator:
-          ocs:
-            channel: stable-4.6
-            sizeGiB: 512
-            storageClass: gp2
+          channel: ${CHANNEL}
+          sizeGiB: 512
+          storageClass: ${STORCLASS}
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/single-cluster/1-infra/kustomization.yaml
+++ b/0-bootstrap/single-cluster/1-infra/kustomization.yaml
@@ -11,9 +11,9 @@ resources:
 #- argocd/namespace-sealed-secrets.yaml
 #- argocd/namespace-tools.yaml
 #- argocd/namespace-openshift-storage.yaml
-#- argocd/operator-ocs.yaml
-#- argocd/refarch-infraconfig.yaml
-#- argocd/refarch-machinesets.yaml
+#- argocd/storage.yaml
+#- argocd/infraconfig.yaml
+#- argocd/machinesets.yaml
 patches:
 - target:
     group: argoproj.io

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/doc/experimental/golden-topology-quickstart.md
+++ b/doc/experimental/golden-topology-quickstart.md
@@ -70,9 +70,7 @@
 - Run the bootstrap script: specify the git org `GIT_ORG`, and the output directory to clone all repos `OUTPUT_DIR`. (Note: you can also specify the git user `GIT_USER`, the IBM Entitlement key value `IBM_ENTITLEMENT_KEY` and others if you are deploying additional features). You can use `DEBUG=true` for verbose output.
     ```bash
     curl -sfL https://raw.githubusercontent.com/cloud-native-toolkit/multi-tenancy-gitops/master/scripts/bootstrap.sh | \
-    GIT_ORG=$GIT_ORG \
-    OUTPUT_DIR=infra-production \
-    bash
+    DEBUG=true GIT_ORG=$GIT_ORG OUTPUT_DIR=infra-production bash
     ```
 
 - To get the ArgoCD/GitOps URL and admin password:

--- a/doc/experimental/golden-topology-quickstart.md
+++ b/doc/experimental/golden-topology-quickstart.md
@@ -69,6 +69,7 @@
 
 - Run the bootstrap script: specify the git org `GIT_ORG`, and the output directory to clone all repos `OUTPUT_DIR`. (Note: you can also specify the git user `GIT_USER`, the IBM Entitlement key value `IBM_ENTITLEMENT_KEY` and others if you are deploying additional features). You can use `DEBUG=true` for verbose output.
     ```bash
+    cd ..
     curl -sfL https://raw.githubusercontent.com/cloud-native-toolkit/multi-tenancy-gitops/master/scripts/bootstrap.sh | \
     DEBUG=true GIT_ORG=$GIT_ORG OUTPUT_DIR=infra-production bash
     ```

--- a/doc/experimental/golden-topology-quickstart.md
+++ b/doc/experimental/golden-topology-quickstart.md
@@ -1,0 +1,122 @@
+# Golden Topology QuickStart
+
+## Experimental: QuickStart for Implementing Infrastructure Golden Topology
+
+### Deploy OpenShift Container Storage and infrastructure+storage nodes
+
+- Make sure you are logged in OpenShift with cluster-admin rights
+    ```bash
+    oc login ...
+    ```
+
+- Log in with the Github CLI
+    ```bash
+    gh auth login
+    ```
+
+- Setup a local git directory to clone all the git repositories
+    ```bash
+    mkdir -p infra-production
+    cd infra-production
+    ```
+
+- Make sure you are connected to the correct OpenShift cluster
+    ```bash
+    oc whoami --show-console
+    ```
+- Setup an **empty** git organization to host your repos (you can also use your primary git userID, but that is provided that you do not have any multi-tenancy repos setup there)
+    ```bash
+    export GIT_ORG=<your_org>
+    ```
+
+- Fork and clone the multi-tenancy-gitops repos to your local directory:
+    ```bash
+    gh repo fork cloud-native-toolkit/multi-tenancy-gitops --clone --org ${GIT_ORG} --remote
+    mv multi-tenancy-gitops gitops-0-bootstrap
+    ```
+- Modify the `kustomization.yaml` to add or remove features, the infrastructure capabilities are in `0-bootstrap/single-cluster/1-infra/kustomization.yaml` and you must enable the lines below:
+
+    ```bash
+    vi 0-bootstrap/single-cluster/1-infra/kustomization.yaml
+    ```
+
+    ```yaml
+    resources:
+    #- argocd/consolelink.yaml
+    #- argocd/consolenotification.yaml
+    #- argocd/namespace-ibm-common-services.yaml
+    #- argocd/namespace-ci.yaml
+    #- argocd/namespace-dev.yaml
+    #- argocd/namespace-staging.yaml
+    #- argocd/namespace-prod.yaml
+    #- argocd/namespace-istio-system.yaml
+    #- argocd/namespace-openldap.yaml
+    #- argocd/namespace-sealed-secrets.yaml
+    #- argocd/namespace-tools.yaml
+    - argocd/namespace-openshift-storage.yaml
+    - argocd/storage.yaml
+    - argocd/infraconfig.yaml
+    - argocd/machinesets.yaml
+    ```
+
+- Commit your changes to the `kustomization.yaml`
+
+    ```bash
+    git add 0-bootstrap/single-cluster/1-infra/kustomization.yaml
+    git commit -m "Enable infrastructure components"
+    git push origin
+    ```
+
+- Run the bootstrap script: specify the git org `GIT_ORG`, and the output directory to clone all repos `OUTPUT_DIR`. (Note: you can also specify the git user `GIT_USER`, the IBM Entitlement key value `IBM_ENTITLEMENT_KEY` and others if you are deploying additional features). You can use `DEBUG=true` for verbose output.
+    ```bash
+    curl -sfL https://raw.githubusercontent.com/cloud-native-toolkit/multi-tenancy-gitops/master/scripts/bootstrap.sh | \
+    GIT_ORG=$GIT_ORG \
+    OUTPUT_DIR=infra-production \
+    bash
+    ```
+
+- To get the ArgoCD/GitOps URL and admin password:
+    ```bash
+    oc get route -n openshift-gitops openshift-gitops-cntk-server -o template --template='https://{{.spec.host}}'
+    oc extract secrets/openshift-gitops-cntk-cluster --keys=admin.password -n openshift-gitops --to=-
+    ```
+
+- Check the nodes being provisioned:
+
+    ```bash
+    watch -n5 oc get nodes,machines -n openshift-machine-api
+    ```
+
+    you should see your infra and storage nodes being provisioned and ready
+
+    ```
+    Every 5.0s: oc get nodes,machines -n openshift-machine-api                                             mbp.local: Fri Sep  3 11:11:36 2021
+
+    NAME                                             STATUS   ROLES            AGE   VERSION
+    node/z2g-cluster2-p45dl-infra-eastus21-z5znc     Ready    infra,worker     60m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-infra-eastus22-8jwl8     Ready    infra,worker     62m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-infra-eastus23-jzldd     Ready    infra,worker     62m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-master-0                 Ready    master           45h   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-master-1                 Ready    master           45h   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-master-2                 Ready    master           45h   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-storage-eastus21-c47hz   Ready    storage,worker   60m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-storage-eastus22-kn4z4   Ready    storage,worker   62m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-storage-eastus23-zgqbl   Ready    storage,worker   62m   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-worker-eastus21-zb28l    Ready    worker           45h   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-worker-eastus22-hfbzx    Ready    worker           45h   v1.20.0+4593a24
+    node/z2g-cluster2-p45dl-worker-eastus23-tkd6k    Ready    worker           45h   v1.20.0+4593a24
+
+    NAME                                                                     PHASE     TYPE               REGION    ZONE   AGE
+    machine.machine.openshift.io/z2g-cluster2-p45dl-infra-eastus21-z5znc     Running   Standard_D4s_v3    eastus2   1      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-infra-eastus22-8jwl8     Running   Standard_D4s_v3    eastus2   2      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-infra-eastus23-jzldd     Running   Standard_D4s_v3    eastus2   3      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-master-0                 Running   Standard_D8s_v3    eastus2   1      45h
+    machine.machine.openshift.io/z2g-cluster2-p45dl-master-1                 Running   Standard_D8s_v3    eastus2   2      45h
+    machine.machine.openshift.io/z2g-cluster2-p45dl-master-2                 Running   Standard_D8s_v3    eastus2   3      45h
+    machine.machine.openshift.io/z2g-cluster2-p45dl-storage-eastus21-c47hz   Running   Standard_D16s_v3   eastus2   1      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-storage-eastus22-kn4z4   Running   Standard_D16s_v3   eastus2   2      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-storage-eastus23-zgqbl   Running   Standard_D16s_v3   eastus2   3      65m
+    machine.machine.openshift.io/z2g-cluster2-p45dl-worker-eastus21-zb28l    Running   Standard_D8s_v3    eastus2   1      45h
+    machine.machine.openshift.io/z2g-cluster2-p45dl-worker-eastus22-hfbzx    Running   Standard_D8s_v3    eastus2   2      45h
+    machine.machine.openshift.io/z2g-cluster2-p45dl-worker-eastus23-tkd6k    Running   Standard_D8s_v3    eastus2   3      45h
+    ```

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -153,7 +153,7 @@ fork_repos () {
 check_infra () {
    if [[ "${ADD_INFRA}" == "yes" ]]; then 
      pushd ${OUTPUT_DIR}/gitops-0-bootstrap
-       bash ./scripts/infra-mod.sh
+       source ./scripts/infra-mod.sh
      popd
    fi
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -151,98 +151,11 @@ fork_repos () {
 }
 
 check_infra () {
-  echo "Applying Infrastructure updates"
-
-  pushd ${OUTPUT_DIR}/gitops-0-bootstrap/0-bootstrap/single-cluster/1-infra
-
-  ocpversion=$(oc get clusterversion version | grep -v NAME | awk '{print $2}')
-  a=( ${ocpversion//./ } )  
-  majorVer="${a[0]}.${a[1]}" 
-  installconfig=$(oc get configmap cluster-config-v1 -n kube-system -o jsonpath='{.data.install-config}')
-  if echo $installconfig|grep 'api.openshift.com/managed';then
-     managed1=$(echo "${installconfig}" | grep "api.openshift.com\/managed" | cut -d":" -f2  )
-     managed=${managed1:-"false"}
-  else
-     managed="false"
-  fi
-
-  infraID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
-  platform=$(echo "${installconfig}" | grep -A1 "platform:" | grep -v "platform:" | head -1 | cut -d":" -f1 | xargs)
-  if [[ "${platform}" == "vsphere" ]]; then 
-    vsconfig=$(echo "${installconfig}" | grep -A12 "^platform:" | grep "^    " | grep -v "  vsphere:")
-    VS_NETWORK=$(echo "${vsconfig}"  | grep "network " | cut -d":" -f2 | xargs)
-    VS_DATACENTER=$(echo "${vsconfig}" | grep "datacenter" | cut -d":" -f2 | xargs)
-    VS_DATASTORE=$(echo "${vsconfig}" | grep "defaultDatastore" | cut -d":" -f2 | xargs)
-    VS_CLUSTER=$(echo "${vsconfig}" | grep "cluster" | cut -d":" -f2 | xargs)
-    VS_SERVER=$(echo "${vsconfig}" | grep "vCenter" | cut -d":" -f2 | xargs)
-  else
-    region=$(echo "${installconfig}" | grep "region:" | cut -d":" -f2  | xargs)
-    if [[ "$platform" == "aws"  ]]; then
-      image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A1 "${region}" | grep hvm | cut -d'"' -f4)
-    elif [[ "$platform" == "azure"  ]]; then
-      image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A3 "azure" | grep '"image"' | cut -d'"' -f4)
-    elif [[ "$platform" == "gcp"  ]]; then
-      image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A3 "gcp" | grep '"image"' | cut -d'"' -f4)
-    fi
-  fi
-  # platform=$(oc get -o jsonpath='{.status.platform}' infrastructure cluster | tr [:upper:] [:lower:])
-
-  ms=$(grep "machinesets.yaml" kustomization.yaml | grep -v "^#" | wc -l)
-
-  if [ $ms -eq 1 ]; then
-    # edit argocd/machinesets.yaml
-    sed -i'.bak' -e "s#\${PLATFORM}#${platform}#" argocd/machinesets.yaml
-    sed -i'.bak' -e "s#\${MANAGED}#${managed}#" argocd/machinesets.yaml
-    sed -i'.bak' -e "s#\${INFRASTRUCTURE_ID}#${infraID}#" argocd/machinesets.yaml
-    if [[ "${platform}" == "vsphere" ]]; then 
-      sed -i'.bak' -e "s#\${VS_NETWORK}#${VS_NETWORK}#" argocd/machinesets.yaml
-      sed -i'.bak' -e "s#\${VS_DATACENTER}#${VS_DATACENTER}#" argocd/machinesets.yaml
-      sed -i'.bak' -e "s#\${VS_DATASTORE}#${VS_DATASTORE}#" argocd/machinesets.yaml
-      sed -i'.bak' -e "s#\${VS_CLUSTER}#${VS_CLUSTER}#" argocd/machinesets.yaml
-      sed -i'.bak' -e "s#\${VS_SERVER}#${VS_SERVER}#" argocd/machinesets.yaml
-    else
-      sed -i'.bak' -e "s#\${REGION}#${region}#" argocd/machinesets.yaml
-      sed -i'.bak' -e "s#\${IMAGE_NAME}#${image}#" argocd/machinesets.yaml
-    fi
-
-    rm argocd/machinesets.yaml.bak
-  fi
-
-  ms=$(grep "infraconfig.yaml" kustomization.yaml | grep -v "^#" | wc -l)
-
-  if [ $ms -eq 1 ]; then
-    # edit argocd/infraconfig.yaml
-    sed -i'.bak' -e "s#\${PLATFORM}#${platform}#" argocd/infraconfig.yaml
-    sed -i'.bak' -e "s#\${MANAGED}#${managed}#" argocd/infraconfig.yaml
-    rm argocd/infraconfig.yaml.bak
-  fi
-
-  ms=$(grep "\/storage.yaml" kustomization.yaml | grep -v "^#" | wc -l)
-
-  if [ $ms -eq 1 ]; then
-    # edit argocd/storage.yaml
-    newChannel="stable-${majorVer}" 
-    defsc=$(oc get sc | grep default | awk '{print $1}')
-    if [[ "$platform" == "aws" ]]; then
-      storageClass=${defsc:-"gp2"}
-    elif [[ "$platform" == "azure" ]]; then
-      storageClass=${defsc:-"managed-premium"}
-    elif [[ "$platform" == "gcp" ]]; then
-      storageClass=${defsc:-"standard"}
-    fi
-
-    sed -i.bak "s#\${CHANNEL}#${newChannel}#" argocd/storage.yaml
-    sed -i.bak "s#\${STORCLASS}#${storageClass}#" argocd/storage.yaml
-    rm argocd/storage.yaml.bak
-  fi
-
-  git add .
-
-  git commit -m "Editing infrastructure definitions"
-
-  git push origin
-
-  popd
+   if [[ "${ADD_INFRA}" == "yes" ]]; then 
+     pushd ${OUTPUT_DIR}/gitops-0-bootstrap
+       bash ./scripts/infra-mod.sh
+     popd
+   fi
 }
 
 install_pipelines () {

--- a/scripts/infra-mod.sh
+++ b/scripts/infra-mod.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+## Script to request infrastructure and storage nodes
+## Script to install OCS
+## Based on Cloud-Native-Toolkit gitops production reference
+
+## Requirements:
+##
+## - A working OpenShift 4.7 cluster on aws/azure/vsphere
+## - The oc command client
+## - Run this script under the multi-tenancy-gitops git structure
+##
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+[[ -n "${DEBUG:-}" ]] && set -x
+
+pushd () {
+    command pushd "$@" > /dev/null
+}
+
+popd () {
+    command popd "$@" > /dev/null
+}
+
+set +e
+oc version --client | grep '4.7\|4.8'
+OC_VERSION_CHECK=$?
+set -e
+if [[ ${OC_VERSION_CHECK} -ne 0 ]]; then
+    echo "Please use oc client version 4.7 or 4.8 download from https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/ "
+fi
+
+# Check whether in GIT multi-tenancy-gitops
+
+pushd ${SCRIPTDIR}/..
+
+if [[ -d "0-bootstrap" ]]; then
+    echo "Finding 0-bootstrap directory."
+else
+    echo "Cannot ensure that you are in multi-tenancy-gitops or its copy"
+    exit 100
+fi
+
+popd
+
+# Check whether OpenShift is connected
+
+set +e
+if oc cluster-info>/dev/null 2>&1; then
+    echo "Cluster is connected"
+else
+    echo "Not connected to a cluster"
+    exit 200
+fi
+set -e
+
+# uncomment the kustomize.yaml - which one?
+
+echo "Applying Infrastructure updates"
+
+pushd ${SCRIPTDIR}/../0-bootstrap/single-cluster/1-infra
+
+ocpversion=$(oc get clusterversion version | grep -v NAME | awk '{print $2}')
+a=( ${ocpversion//./ } )
+majorVer="${a[0]}.${a[1]}"
+installconfig=$(oc get configmap cluster-config-v1 -n kube-system -o jsonpath='{.data.install-config}')
+if echo $installconfig|grep 'api.openshift.com/managed';then
+    managed1=$(echo "${installconfig}" | grep "api.openshift.com\/managed" | cut -d":" -f2  )
+    managed=${managed1:-"false"}
+else
+    managed="false"
+fi
+
+infraID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
+platform=$(echo "${installconfig}" | grep -A1 "platform:" | grep -v "platform:" | head -1 | cut -d":" -f1 | xargs)
+shopt -s extglob
+if [[ $platform == @(aws|azure|vsphere) ]]; then
+    echo "Platform ${platform} is valid"
+else
+    echo "Supported platform is not found"
+    exit 300
+fi
+
+if [[ "${platform}" == "vsphere" ]]; then
+    vsconfig=$(echo "${installconfig}" | grep -A12 "^platform:" | grep "^    " | grep -v "  vsphere:")
+    VS_NETWORK=$(echo "${vsconfig}"  | grep "network " | cut -d":" -f2 | xargs)
+    VS_DATACENTER=$(echo "${vsconfig}" | grep "datacenter" | cut -d":" -f2 | xargs)
+    VS_DATASTORE=$(echo "${vsconfig}" | grep "defaultDatastore" | cut -d":" -f2 | xargs)
+    VS_CLUSTER=$(echo "${vsconfig}" | grep "cluster" | cut -d":" -f2 | xargs)
+    VS_SERVER=$(echo "${vsconfig}" | grep "vCenter" | cut -d":" -f2 | xargs)
+else
+    region=$(echo "${installconfig}" | grep "region:" | cut -d":" -f2  | xargs)
+    if [[ "$platform" == "aws"  ]]; then
+        image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A1 "${region}" | grep hvm | cut -d'"' -f4)
+        elif [[ "$platform" == "azure"  ]]; then
+        image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A3 "azure" | grep '"image"' | cut -d'"' -f4)
+        elif [[ "$platform" == "gcp"  ]]; then
+        image=$(curl -k -s https://raw.githubusercontent.com/openshift/installer/release-${majorVer}/data/data/rhcos.json | grep -A3 "gcp" | grep '"image"' | cut -d'"' -f4)
+    fi
+fi
+# platform=$(oc get -o jsonpath='{.status.platform}' infrastructure cluster | tr [:upper:] [:lower:])
+
+sed -i.bak '/machinesets.yaml/s/^#//g' kustomization.yaml
+rm kustomization.yaml.bak
+
+# edit argocd/machinesets.yaml
+sed -i'.bak' -e "s#\${PLATFORM}#${platform}#" argocd/machinesets.yaml
+sed -i'.bak' -e "s#\${MANAGED}#${managed}#" argocd/machinesets.yaml
+sed -i'.bak' -e "s#\${INFRASTRUCTURE_ID}#${infraID}#" argocd/machinesets.yaml
+if [[ "${platform}" == "vsphere" ]]; then
+    sed -i'.bak' -e "s#\${VS_NETWORK}#${VS_NETWORK}#" argocd/machinesets.yaml
+    sed -i'.bak' -e "s#\${VS_DATACENTER}#${VS_DATACENTER}#" argocd/machinesets.yaml
+    sed -i'.bak' -e "s#\${VS_DATASTORE}#${VS_DATASTORE}#" argocd/machinesets.yaml
+    sed -i'.bak' -e "s#\${VS_CLUSTER}#${VS_CLUSTER}#" argocd/machinesets.yaml
+    sed -i'.bak' -e "s#\${VS_SERVER}#${VS_SERVER}#" argocd/machinesets.yaml
+else
+    sed -i'.bak' -e "s#\${REGION}#${region}#" argocd/machinesets.yaml
+    sed -i'.bak' -e "s#\${IMAGE_NAME}#${image}#" argocd/machinesets.yaml
+fi
+
+rm argocd/machinesets.yaml.bak
+
+
+sed -i.bak '/infraconfig.yaml/s/^#//g' kustomization.yaml
+rm kustomization.yaml.bak
+
+# edit argocd/infraconfig.yaml
+sed -i'.bak' -e "s#\${PLATFORM}#${platform}#" argocd/infraconfig.yaml
+sed -i'.bak' -e "s#\${MANAGED}#${managed}#" argocd/infraconfig.yaml
+rm argocd/infraconfig.yaml.bak
+
+sed -i.bak '/namespace-openshift-storage.yaml/s/^#//g' kustomization.yaml
+sed -i.bak '/storage.yaml/s/^#//g' kustomization.yaml
+rm kustomization.yaml.bak
+# edit argocd/storage.yaml
+newChannel="stable-${majorVer}"
+defsc=$(oc get sc | grep default | awk '{print $1}')
+if [[ "$platform" == "aws" ]]; then
+    storageClass=${defsc:-"gp2"}
+    elif [[ "$platform" == "azure" ]]; then
+    storageClass=${defsc:-"managed-premium"}
+    elif [[ "$platform" == "gcp" ]]; then
+    storageClass=${defsc:-"standard"}
+fi
+
+sed -i.bak "s#\${CHANNEL}#${newChannel}#" argocd/storage.yaml
+sed -i.bak "s#\${STORCLASS}#${storageClass}#" argocd/storage.yaml
+rm argocd/storage.yaml.bak
+
+
+popd
+
+pushd "${SCRIPTDIR}/.."
+
+${SCRIPTDIR}/sync-manifests.sh
+
+git add .
+
+git commit -m "Editing infrastructure definitions"
+
+git push origin
+
+popd

--- a/setup/ocp47/custom-argocd-app-controller-clusterrole.yaml
+++ b/setup/ocp47/custom-argocd-app-controller-clusterrole.yaml
@@ -209,6 +209,19 @@ rules:
   - verbs:
       - '*'
     apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigpools
+      - containerruntimeconfigs
+  - verbs:
+      - '*'
+    apiGroups:
+      - tuned.openshift.io
+    resources:
+      - tuneds
+  - verbs:
+      - '*'
+    apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
@@ -218,6 +231,18 @@ rules:
       - processmining.ibm.com
     resources:
       - processminings
+  - verbs:
+      - '*'
+    apiGroups:
+      - ocs.openshift.io
+    resources:
+      - storageclusters
+  - verbs:
+      - '*'
+    apiGroups:
+      - imageregistry.operator.openshift.io
+    resources:
+      - configs
   - verbs:
       - '*'
     apiGroups:


### PR DESCRIPTION
This pull request has pre-requisites of other pull requests:
- https://github.com/cloud-native-toolkit/multi-tenancy-gitops-infra/pull/11
- https://github.com/cloud-native-toolkit/toolkit-charts/pull/237

The modification will allow easy modification for adding Infrastructure and storage nodes, reallocate the pods and install OCS.... The pre-requisite for this is to enable in 0-bootstrap/single-cluster/1-infra/kustomization.yaml to enable:
```
- argocd/namespace-openshift-storage.yaml
- argocd/storage.yaml
- argocd/infraconfig.yaml
- argocd/machinesets.yaml
```