### PR TITLE
Issue 111 - Update bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -168,7 +168,6 @@ delete_default_argocd_instance () {
     echo "Delete the default ArgoCD instance"
     pushd ${OUTPUT_DIR}
     oc delete gitopsservice cluster -n openshift-gitops || true
-    oc delete argocd openshift-gitops -n openshift-gitops || true
     popd
 }
 


### PR DESCRIPTION
Signed-off-by: hollisc <hollisc@ca.ibm.com>

Fix for https://github.com/cloud-native-toolkit/multi-tenancy-gitops/issues/111 due to recent fix in OpenShift GitOps, where deletion of the `gitopsservice` CR will delete the default `ArgoCD` instance. 