### PR TITLE
Update IBM MQ operator Channel to 1.6

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmmq:
               name: ibm-mq
               subscription:
-                channel: v1.5
+                channel: v1.6
                 installPlanApproval: Automatic
                 name: ibm-mq
                 source: ibm-operator-catalog


### PR DESCRIPTION
Signed-off-by: hollisc <hollisc@ca.ibm.com>

Issue: https://github.com/cloud-native-toolkit/multi-tenancy-gitops/issues/121