### PR TITLE
update infra-mod platform detection

### DIFF
--- a/scripts/infra-mod.sh
+++ b/scripts/infra-mod.sh
@@ -72,7 +72,7 @@ else
 fi
 
 infraID=$(oc get -o jsonpath='{.status.infrastructureName}' infrastructure cluster)
-platform=$(echo "${installconfig}" | grep -A1 "platform:" | grep -v "platform:" | head -1 | cut -d":" -f1 | xargs)
+platform=$(echo "${installconfig}" | grep -A1 "^platform:" | grep -v "platform:" | cut -d":" -f1 | xargs)
 shopt -s extglob
 if [[ $platform == @(aws|azure|vsphere) ]]; then
     echo "Platform ${platform} is valid"


### PR DESCRIPTION
infra-mod provisioning logic picked up the wrong line when detecting platform, which would break infrastructure automation. 
**BEFORE**:
```bash
$ echo "${installconfig}" | grep -A1 "platform:"
  platform: {}
  replicas: 3
--
  platform:
    aws:
--
platform:
  aws:
$ echo "${installconfig}" | grep -A1 "platform:" | grep -v "platform:" | head -1 | cut -d":" -f1 | xargs
replicas
```

**AFTER**:
```bash
$ echo "${installconfig}" | grep -A1 "^platform:"
platform:
  aws:
$ echo "${installconfig}" | grep -A1 "^platform:" | grep -v "platform:" | cut -d":" -f1 | xargs
aws
```