### PR TITLE
console notification plus sync manifest

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/namespace-tools.yaml
@@ -8,7 +8,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "100"
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: tools
     server: https://kubernetes.default.svc
   project: infra
   source:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/serviceaccounts-tools.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sa-tools
+  labels:
+    gitops.tier.layer: infra
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+spec:
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: infra
+  source:
+    path: serviceaccounts/tools
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/artifactory.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/cert-manager-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/chartmuseum.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/developer-dashboard.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/grafana-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: tools

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-gateway-analytics-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
   spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-management-portal-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: applications
+    gitops.tier.source: git
 spec:
   destination:
     namespace: openshift-gitops

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4d-watson-studio-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.1
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ws-cr
+      - name: spec.docker_registry_prefix
+        value: cp.icr.io/cp/cpd
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.storageCLass
+        value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4sthreatmanagements-instance.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4sthreatmanagements-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cp4sthreatmanagements-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: threatmgmt
+      - name: spec.acceptLicense
+        value: "true"
+      - name: spec.basicDeploymentConfiguration.adminUser
+        value: adminUser
+      - name: spec.basicDeploymentConfiguration.storageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.airgapInstall
+        value: "false"
+      - name: spec.extendedDeploymentConfiguration.backupStorageClass
+        value: managed-nfs-storage
+      - name: spec.extendedDeploymentConfiguration.backupStorageSize
+        value: ''
+      - name: spec.extendedDeploymentConfiguration.imagePullPolicy
+        value: IfNotPresent
+      - name: spec.extendedDeploymentConfiguration.repository
+        value: cp.icr.io/cp/cp4s
+      - name: spec.extendedDeploymentConfiguration.repositoryType
+        value: entitled
+      - name: spec.extendedDeploymentConfiguration.roksAuthentication
+        value: "false"
+      - name: spec.threatManagementCapabilities.deployDRC
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployRiskManager
+        value: "true"
+      - name: spec.threatManagementCapabilities.deployThreatInvestigator
+        value: "true"

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-foundational-services-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-platform-navigator-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/instana-agent.yaml
@@ -6,9 +6,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "250"
   labels:
     gitops.tier.group: cntk
-    gitops.tier.layer: services    
+    gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
-    - resources-finalizer.argocd.argoproj.io    
+    - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
     namespace: instana-agent
@@ -148,9 +149,9 @@ spec:
                 NodesOrServers: # Multiple Integration node instances or multiple standalone Integration Servers can be specified
                   create-customer-details-rest:  # specify the Integration node name (required)
                         # Following parameters used to acess ACE server's rest api service to retrieve such as status data, configuration data etc
-                    restApiPort: '7600'           # ACE server's rest api port (required)     
+                    restApiPort: '7600'           # ACE server's rest api port (required)
 
-              org.ops4j.pax.logging.cfg: 
+              org.ops4j.pax.logging.cfg:
                 log4j2.logger.instana.level: 'DEBUG'
 
             # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/openldap.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/openshift-service-mesh-instance.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
 spec:
   destination:
     namespace: istio-system

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/pact-broker.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/sealed-secrets.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/sonarqube.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/swaggereditor.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/cert-manager.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/elasticsearch.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/grafana-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-aspera-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-assetrepository-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4a-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4d-watson-studio-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4d-watson-studio-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cpd-ws-operator-catalog-subscription
+      - name: spec.channel
+        value: v2.0
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wsl
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4i-operators.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cp4s-operator.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cp4s-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+    gitops.tier.source: git
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: tools
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-cp-security-operator
+      - name: spec.channel
+        value: v1.8
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cp-security-operator
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace
+      - name: spec.config.resources.limits.cpu
+        value: 200m
+      - name: spec.config.resources.limits.memory
+        value: 300Mi
+      - name: spec.config.resources.requests.cpu
+        value: 150m
+      - name: spec.config.resources.requests.memory
+        value: 200Mi

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-eventstreams-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-foundations.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-mq-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-opsdashboard-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-platform-navigator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-process-mining-operator.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: ibm-cloudpak
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/jaeger.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/kiali.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-gitops.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-pipelines.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: cntk
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/openshift-service-mesh.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     gitops.tier.group: service-mesh
     gitops.tier.layer: services
+    gitops.tier.source: git
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/0-bootstrap/single-cluster/1-infra/argocd/consolenotification.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/consolenotification.yaml
@@ -28,7 +28,7 @@ spec:
           ## The background color that should be used for the banner
           backgroundColor: teal
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/doc/scenarios/apic-multi-cluster/gateway-analytics-cluster/1-infra/argocd/consolenotification.yaml
+++ b/doc/scenarios/apic-multi-cluster/gateway-analytics-cluster/1-infra/argocd/consolenotification.yaml
@@ -26,9 +26,9 @@ spec:
           name: "banner-env"
 
           ## The background color that should be used for the banner
-          backgroundColor: "#DC7633"
+          backgroundColor: "'#DC7633'"
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/doc/scenarios/apic-multi-cluster/management-portal-cluster/1-infra/argocd/consolenotification.yaml
+++ b/doc/scenarios/apic-multi-cluster/management-portal-cluster/1-infra/argocd/consolenotification.yaml
@@ -26,9 +26,9 @@ spec:
           name: "banner-env"
 
           ## The background color that should be used for the banner
-          backgroundColor: '#138D75'
+          backgroundColor: "'#138D75'"
           ## The color of the text that will appear in the banner
-          color: "#fff"
+          color: "'#fff'"
           ## The location of the banner. Options: BannerTop, BannerBottom, BannerTopBottom
           location: BannerTop
           ## The text that should be displayed in the banner. This value is required for the banner to be created

--- a/scripts/sync-manifests.sh
+++ b/scripts/sync-manifests.sh
@@ -6,6 +6,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOTDIR="$(cd ${SCRIPTDIR}/..; pwd )"
 [[ -n "${DEBUG:-}" ]] && set -x
 
+cd ${SCRIPTDIR}/..
+
 for LAYER in 1-infra 2-services 3-apps
 do
 


### PR DESCRIPTION
Made a change to `scripts/sync-manifests.sh` so that it can be called from anywhere as opposed to how it was till now that must have be called from `multi-tenancy-gitops` with `./scripts/sync-manifests.sh`

Made changes to 
- `0-bootstrap/single-cluster/1-infra/argocd/consolenotification.yaml`
- `doc/scenarios/apic-multi-cluster/gateway-analytics-cluster/1-infra/argocd/consolenotification.yaml`
- `doc/scenarios/apic-multi-cluster/management-portal-cluster/1-infra/argocd/consolenotification.yaml`
so that the color values stick in the creation and are not interpreted as a comment. These should have been propagated with `sync-manifest.sh`

However, as a result of that `sync-manifest.sh` execution I seem to be pushing changes from previous PRs...