### PR TITLE
fix in DB2 operator namespace

### DIFF
--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-db2u-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-db2u-operator.yaml
@@ -12,7 +12,7 @@ metadata:
     - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: openshift-operators
+    namespace: tools
     server: 'https://kubernetes.default.svc'
   project: services
   source:


### PR DESCRIPTION
IBM DB2 Operator must be installed namespaced. Therefore, installing it in the tools namespace where IBM Process Mining will be installed and expects it in.

Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>