### PR TITLE
Bumping API Connect version

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/single-cluster/2-services/argocd/instances/ibm-apic-instance.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/instances/ibm-apic-instance.yaml
@@ -30,7 +30,7 @@ spec:
               license:
                 accept: true
                 use: production
-                license: L-RJON-BZEP9N
-              version: 10.0.3.0-ifix1
+                license: L-RJON-C7QFWS
+              version: 10.0.4.0
               profile: n3xc14.m48
               storageClassName: ibmc-block-gold

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-apic-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-apic-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmapic:
               name: ibm-apic
               subscription:
-                channel: v2.3
+                channel: v2.4
                 installPlanApproval: Automatic
                 name: ibm-apiconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-datapower-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-datapower-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmdatapower:
               name: ibm-datapower
               subscription:
-                channel: v1.4
+                channel: v1.5
                 installPlanApproval: Automatic
                 name: datapower-operator
                 source: ibm-operator-catalog


### PR DESCRIPTION
Changes to bump API Connect to version `10.0.4.0` which was released last night --> https://www.ibm.com/support/pages/node/6508607
Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>