### PR TITLE
remove description from AppProjects

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/2-services.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cp4d-watson-studio-instance.yaml
@@ -20,18 +20,16 @@ spec:
   source:
     chart: ibm-cp4d-watson-studio-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
         value: ws-cr
-      - name: spec.docker_registry_prefix
-        value: cp.icr.io/cp/cpd
       - name: spec.license.accept
         value: "true"
       - name: spec.license.license
         value: Enterprise
-      - name: spec.scaleConfig
-        value: small
+      - name: spec.version
+        value: 4.0.4
       - name: spec.storageClass
         value: managed-nfs-storage

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-instance.yaml
@@ -18,7 +18,7 @@ spec:
   source:
     chart: ibm-cpd-platform-instance
     repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
-    targetRevision: 0.1.1
+    targetRevision: 0.1.2
     helm:
       parameters:
       - name: metadata.name
@@ -29,10 +29,6 @@ spec:
         value: "Enterprise"
       - name: spec.storageClass
         value: "managed-nfs-storage"
-      - name: spec.zenCoreMetadbStorageClass
-        value: "managed-nfs-storage"
-      - name: spec.version
-        value: "4.0.1"
   syncPolicy:
     automated:
       prune: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-platform-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdplatform:
               name: ibm-cpd-platform-catalog-subscription
               subscription:
-                channel: stable-v1
+                channel: v2.0
                 installPlanApproval: Automatic
                 name: cpd-platform-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-scheduling-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmcpdscheduling:
               name: ibm-cpd-scheduling-catalog-subscription
               subscription:
-                channel: alpha
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-cpd-scheduling-operator
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/1-infra/1-infra.yaml
+++ b/0-bootstrap/single-cluster/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/2-services/2-services.yaml
+++ b/0-bootstrap/single-cluster/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/3-apps/3-apps.yaml
+++ b/0-bootstrap/single-cluster/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    description: Read-only privileges to my-project
+    # description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:


### PR DESCRIPTION
Argo was giving the following error
error validating data: ValidationError(AppProject.spec.roles[0]): unknown field "description" in io.argoproj.v1alpha1.AppProject.spec.roles

for the 
- single-cluster/1-infra/1-infra.yaml
- single-cluster/2-services/2-services.yaml
- single-cluster/3-apps/3-apps.yaml

I updated those files and ran ./scripts/sync-manifests.sh but it looks to have propagated other changes to the profiles so not sure if that is desired.


Signed-off-by: Larry Steck <lsteck@us.ibm.com>