### PR TITLE
add back AppProject.spec.roles.description

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/2-services.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/2-services.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/3-apps.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/1-infra/1-infra.yaml
+++ b/0-bootstrap/single-cluster/1-infra/1-infra.yaml
@@ -72,7 +72,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/2-services/2-services.yaml
+++ b/0-bootstrap/single-cluster/2-services/2-services.yaml
@@ -81,7 +81,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:

--- a/0-bootstrap/single-cluster/3-apps/3-apps.yaml
+++ b/0-bootstrap/single-cluster/3-apps/3-apps.yaml
@@ -35,7 +35,7 @@ spec:
   roles:
   # A role which provides read-only access to all applications in the project
   - name: read-only
-    # description: Read-only privileges to my-project
+    description: Read-only privileges to my-project
     policies:
     - p, proj:my-project:read-only, applications, get, my-project/*, allow
     groups:


### PR DESCRIPTION
Red Hat fixed their GitOps operator so we can add the description back

Signed-off-by: Larry Steck <lsteck@us.ibm.com>