### PR TITLE
Adding APIC argoCD app for APIC on CP4i

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/kustomization.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 

--- a/0-bootstrap/single-cluster/3-apps/argocd/apic/single-cluster-cp4i.yaml
+++ b/0-bootstrap/single-cluster/3-apps/argocd/apic/single-cluster-cp4i.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps-apic-single-cluster-cp4i
+  annotations:
+    argocd.argoproj.io/sync-wave: "300"
+  labels:
+    gitops.tier.layer: applications
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: openshift-gitops
+    server: https://kubernetes.default.svc
+  project: applications
+  source:
+    path: apic/config/argocd/single-cluster-cp4i
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/0-bootstrap/single-cluster/3-apps/kustomization.yaml
+++ b/0-bootstrap/single-cluster/3-apps/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 #- argocd/apic/stage.yaml
 #- argocd/apic/prod.yaml
 #- argocd/apic/single-cluster.yaml
+#- argocd/apic/single-cluster-cp4i.yaml
 #- argocd/apic/multi-cluster-app.yaml
 #- argocd/apic/multi-cluster-ops.yaml
 


### PR DESCRIPTION
Adding APIC argoCD app for APIC on CP4i since it will need its specific structure and files down in the `multi-tenancy-gitops-apps` repo.

Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>