### PR TITLE
adding gh version warning

### DIFF
--- a/scripts/create-repos.sh
+++ b/scripts/create-repos.sh
@@ -21,6 +21,19 @@ popd () {
 
 command -v gh >/dev/null 2>&1 || { echo >&2 "The Github CLI gh but it's not installed. Download https://github.com/cli/cli "; exit 1; }
 
+gh_version_long=$(gh --version | grep version | sed 's/gh version //g' | sed 's/ .*//g')
+gh_version=$(echo ${gh_version_long} | sed 's/.[0-9]$//g')
+min_req_gh_version="2.5"
+
+echo "Your Github CLI (gh) version is: ${gh_version_long}"
+
+if [ 1 -eq "$(echo "${gh_version} < ${min_req_gh_version}" | bc)" ]
+then  
+    echo "--> We recommend you to have your GitHub CLI (gh) version to ${min_req_gh_version} or newer to avoid errors in this script."
+    echo "--> You can check your GitHub CLI (gh) version executing: gh --version."
+    echo "--> You can find more information about the GitHub CLI (gh) in https://github.com/cli/cli"
+fi
+
 set +e
 oc version --client | grep '4.7\|4.8'
 OC_VERSION_CHECK=$?


### PR DESCRIPTION
Created the following GitHub CLI version check so that people is aware the script might fail as a result of having an old version of the `gh` cli. 

This comes as a result of having the script fail for me with the following error:

```
Client Version: 4.7.32
Creating GitHub repositories and local clones in folder: .
Github user/org is apic-refactor-48
gh: Not Found (HTTP 404)
Repository multi-tenancy-gitops not found, creating from template and cloning
unknown flag: --clone

Usage:  gh repo create [<name>] [flags]

Flags:
  -y, --confirm               Skip the confirmation prompt
  -d, --description string    Description of the repository
      --enable-issues         Enable issues in the new repository (default true)
      --enable-wiki           Enable wiki in the new repository (default true)
  -g, --gitignore string      Specify a gitignore template for the repository
  -h, --homepage URL          Repository home page URL
      --internal              Make the new repository internal
  -l, --license string        Specify an Open Source License for the repository
      --private               Make the new repository private
      --public                Make the new repository public
  -t, --team name             The name of the organization team to be granted access
  -p, --template repository   Make the new repository based on a template repository
```

because the version of the `gh` cli I had installed on my laptop was `2.0.0` and for that version the `--clone` flag did not exist.

I've implemented a warning so that people is aware that if the script fails with some `gh` command it might be because of their `gh` cli version as opposed to enforcing specific versions to be more flexible but it can be changed to terminate in case we want to ensure people have their `gh` cli on `2.5.0` at least. 

Signed-off-by: Jesus Almaraz <jesus.mah@gmail.com>