### PR TITLE
228 - Added rule for ArgoCD to be able to deploy ServiceMonitor

### DIFF
--- a/setup/ocp4x/custom-argocd-app-controller-clusterrole.yaml
+++ b/setup/ocp4x/custom-argocd-app-controller-clusterrole.yaml
@@ -366,3 +366,9 @@ rules:
       - ds.cpd.ibm.com
     resources:
       - datastages
+  - verbs:
+      - '*'
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors


### PR DESCRIPTION
For MQ monitoring ArgoCD will need to deploy ServiceMonitor resources to establish the communication between the metrics application and Prometheus.