### PR TITLE
Pm version update

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/single-cluster/2-services/argocd/instances/ibm-process-mining-instance.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/instances/ibm-process-mining-instance.yaml
@@ -31,5 +31,5 @@ spec:
               license:
                 accept: true
                 cloudPak: IBM Cloud Pak for Business Automation
-              version: 1.12.0.3
+              version: 1.12.0.4
 

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-automation-foundation-core-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmautomation:
               name: ibm-automation-foundation-core
               subscription:
-                channel: v1.2
+                channel: v1.3
                 installPlanApproval: Automatic
                 name: ibm-automation-core
                 source: iaf-core-operators

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-catalogs.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-catalogs.yaml
@@ -27,7 +27,7 @@ spec:
                 displayName: IBMCS Operators
                 publisher: IBM
                 sourceType: grpc
-                image: docker.io/ibmcom/ibm-common-service-catalog:latest
+                image: icr.io/cpopen/ibm-common-service-catalog:latest
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -60,7 +60,7 @@ spec:
                 displayName: IBM ProcessMining Operators
                 publisher: IBM
                 sourceType: grpc
-                image: icr.io/cpopen/processmining-operator-catalog:1.0.6
+                image: icr.io/cpopen/processmining-operator-catalog:1.1.0
                 updateStrategy:
                   registryPoll:
                     interval: 45m
@@ -70,7 +70,7 @@ spec:
                 displayName: IBM Db2U Catalog
                 publisher: IBM
                 sourceType: grpc
-                image: ibmcom/ibm-db2uoperator-catalog@sha256:7e416ff563492b05daf270e3d8792b1edb70cf6e03bd6a1afca3bc1110f39346
+                image: icr.io/cpopen/ibm-db2uoperator-catalog@sha256:99f725098b801474ff77e880ca235023452116e4b005e49de613496a1917f719
                 updateStrategy:
                   registryPoll:
                     interval: 45m

--- a/doc/process-mining-recipe.md
+++ b/doc/process-mining-recipe.md
@@ -13,6 +13,5 @@
     - argocd/instances/ibm-process-mining-instance.yaml
     - argocd/operators/ibm-db2u-operator.yaml
     - argocd/operators/ibm-foundations.yaml
-    - argocd/operators/ibm-automation-foundation-core-operator.yaml
     - argocd/operators/ibm-catalogs.yaml
     ```


### PR DESCRIPTION
There are two commits here.

The first one is the result of running `sync-manifest.sh` and finding someone else deliver stuff prior to me but did not run synced manifests.

The second one corresponds to the update of the PM version that now sorts the issues with DB2 that prevented a successful installation of PM in ROKS. Main changes are:

- PM instance version from `12.0.0.3` to `12.0.0.4`
- IAF Core Operator from version `1.2` to `1.3`
- Their respective catalog versions so that those latests versions are available to install. **IMPORTANT:** I have updated the common services catalog to use the docker image in the official IBM repo --> `icr.io` as opposed to the `dockerhub` version. I  guess this will have an impact on everyone's work as we're pulling from Common Services from a different location but the Common Services being installed should be the same.

On the catalogs, @csantanapr and @hollisc, I would also like to make another comment. I believe we need to do some refactoring to the catalogs and clean them up to only use the main IBM Operator Catalog:

```
            ibmoperators:
              name: ibm-operator-catalog
              catalog:
                displayName: "IBM Operator Catalog"
                publisher: IBM
                sourceType: grpc
                image: icr.io/cpopen/ibm-operator-catalog:latest
                updateStrategy:
                  registryPoll:
                    interval: 45m
```

As all catalogs should be delivered to this main IBM Catalog in the same manner all IBM Software docker images should be delivered to `icr.io`. Hence, we should not be defining specific tailored versions of certain catalogs. This is something that some products sneakily recommend and document in KC since I guess they have tested and GA'ed their products with specific versions of the IAF or DB2 catalogs. But this ties with the conversation that @csantanapr brought up the other day in the standup. New versions of the catalogs, at least not major-world-changing versions, should be backwards compatible. That is, if PM in this case tested his `12.0.0.4` version of their product with the DB2 version being shipped in the DB2 catalog version `x.y.z`, that same PM version should work with the DB2 catalog version `latest`. That is, the latest versions of each catalog should be backwards compatible in the sense that PM can rely on the `latest` version of catalogs to be able to deploy whatever specific version of DB2 it needs. At least for minor version updates very much like the newer version of the PM Operator still allows you to deploy older PM versions such as `12.0.0.3`.

Not sure I explained well my point here but happy to discuss it on Webex and start to tackle these version updates, dependencies, etc so that we can drive development towards not requiring specific pinned versions of anything as that would break installing different capabilities in a cluster.