### PR TITLE
option to specify custom argocd instance namespace

### DIFF
--- a/0-bootstrap/single-cluster/kustomization.yaml
+++ b/0-bootstrap/single-cluster/kustomization.yaml
@@ -60,3 +60,10 @@ patches:
     - op: add
       path: /spec/sourceRepos/-
       value: ${GIT_BASEURL}/${GIT_ORG}/${GIT_GITOPS_APPLICATIONS}
+- target:
+    group: argoproj.io
+    kind: Application
+  patch: |-
+    - op: replace
+      path: /spec/destination/namespace
+      value: ${GIT_GITOPS_NAMESPACE}

--- a/scripts/set-git-source.sh
+++ b/scripts/set-git-source.sh
@@ -20,6 +20,7 @@ GIT_GITOPS_SERVICES=${GIT_GITOPS_SERVICES:-multi-tenancy-gitops-services.git}
 GIT_GITOPS_SERVICES_BRANCH=${GIT_GITOPS_SERVICES_BRANCH:-${GIT_BRANCH}}
 GIT_GITOPS_APPLICATIONS=${GIT_GITOPS_APPLICATIONS:-multi-tenancy-gitops-apps.git}
 GIT_GITOPS_APPLICATIONS_BRANCH=${GIT_GITOPS_APPLICATIONS_BRANCH:-${GIT_BRANCH}}
+GIT_GITOPS_NAMESPACE=${GIT_GITOPS_NAMESPACE:-openshift-gitops}
 HELM_REPOURL=${HELM_REPOURL:-https://charts.cloudnativetoolkit.dev}
 
 
@@ -41,6 +42,7 @@ find ${SCRIPTDIR}/../0-bootstrap -name '*.yaml' -print0 |
       sed -i'.bak' -e "s#\${GIT_GITOPS_SERVICES_BRANCH}#${GIT_GITOPS_SERVICES_BRANCH}#" $File
       sed -i'.bak' -e "s#\${GIT_BASEURL}/\${GIT_ORG}/\${GIT_GITOPS_APPLICATIONS}#${GIT_BASEURL}/${GIT_ORG}/${GIT_GITOPS_APPLICATIONS}#" $File
       sed -i'.bak' -e "s#\${GIT_GITOPS_APPLICATIONS_BRANCH}#${GIT_GITOPS_APPLICATIONS_BRANCH}#" $File
+      sed -i'.bak' -e "s#\${GIT_GITOPS_NAMESPACE}#${GIT_GITOPS_NAMESPACE}#" $File
       sed -i'.bak' -e "s#\${HELM_REPOURL}#${HELM_REPOURL}#" $File
       rm "${File}.bak"
     fi

--- a/setup/ocp4x/argocd-instance/argocd-instance.yaml
+++ b/setup/ocp4x/argocd-instance/argocd-instance.yaml
@@ -57,6 +57,7 @@ spec:
       ignoreDifferences: |
         jsonPointers:
         - /metadata/annotations/olm.providedAPIs
+        - /status/lastUpdated
     argoproj.io/Application:
       health.lua: |
         hs = {}
@@ -550,6 +551,76 @@ spec:
           end
         end
         hs.status = "Progressing"
+        return hs
+    operator.open-cluster-management.io/MultiClusterHub:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.phase
+            if obj.status.phase == "Running" then
+              hs.status = "Healthy"
+            else
+              hs.status = "Progressing"
+            end
+            return hs
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Unknown"
+        return hs
+    machine.openshift.io/obj.sta:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          hs.message = "Not Ready"
+          if obj.status.replicas == 0 then
+            hs.status = "Healthy"
+            return hs
+          end
+          if obj.status.replicas == obj.status.availableReplicas then
+            hs.status = "Healthy"
+          else
+            hs.status = "Progressing"
+          end
+          return hs
+        end
+        hs.status = "Progressing"
+        hs.message = "Unknown"
+        return hs
+    hive.openshift.io/ClusterDeployment:
+      health.lua: |
+        hs = {}
+        generation = obj.metadata.generation
+        if obj.status ~= nil then
+          if obj.status.conditions ~= nil then
+            for i, condition in ipairs(obj.status.conditions) do
+              if condition.type == "Hibernating" and condition.status == "False" then
+                hs.status = "Healthy"
+                hs.message = condition.message
+                return hs
+              end
+            end
+          end
+        end
+        hs.status = "Progressing"
+        return hs
+    ocs.openshift.io/StorageCluster:
+      health.lua: |
+        hs = {}
+        if obj.status ~= nil then
+          if obj.status.phase ~= nil then
+            hs.message = obj.status.phase
+            if obj.status.phase == "Ready" then
+              hs.status = "Healthy"
+            else
+              hs.status = "Progressing"
+            end
+            return hs
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Unknown"
         return hs
   applicationSet:
     resources:

--- a/setup/ocp4x/custom-argocd-app-controller-clusterrole.yaml
+++ b/setup/ocp4x/custom-argocd-app-controller-clusterrole.yaml
@@ -238,6 +238,12 @@ rules:
       - ocs.openshift.io
     resources:
       - storageclusters
+  - apiGroups:
+      - odf.openshift.io
+    resources:
+      - storagesystems
+    verbs:
+      - '*'
   - verbs:
       - '*'
     apiGroups:

--- a/setup/ocp4x/openshift-gitops-operator.yaml
+++ b/setup/ocp4x/openshift-gitops-operator.yaml
@@ -9,3 +9,7 @@ spec:
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  config:
+    env:
+    - name: DISABLE_DEFAULT_ARGOCD_INSTANCE
+      value: 'TRUE'


### PR DESCRIPTION
1. Do not deploy default ArgoCD instance (DISABLE_DEFAULT_ARGOCD_INSTANCE = True)
2. Option to deploy ArgoCD instance in custom namespace (GIT_GITOPS_NAMESPACE)
Signed-off-by: Noel Colon <ncolon@us.ibm.com>