### PR TITLE
updated OCS/ODF operator detection

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/instances/ibm-cpd-wos-instance.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-instance
+  annotations:
+    argocd.argoproj.io/sync-wave: "270"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    #gitops.tier.layer: services
+    gitops.tier.source: helm
+spec:
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  destination:
+    namespace: tools
+    server: https://kubernetes.default.svc
+  project: services
+  source:
+    chart: ibm-cpd-wos-instance
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 0.1.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: aiopenscale
+      - name: spec.license.accept
+        value: "true"
+      - name: spec.license.license
+        value: Enterprise
+      - name: spec.version
+        value: 4.0.2
+      - name: spec.storageClass
+        value: managed-nfs-storage
+      - name: spec.scaleConfig
+        value: small
+      - name: spec.type
+        value: service
+      - name: spec.ignoreForMaintenance
+        value: "false"

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-cpd-wos-operator.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ibm-cpd-wos-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "230"
+  labels:
+    gitops.tier.group: ibm-cloudpak
+    gitops.tier.layer: services
+    gitops.tier.source: helm
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ibm-common-services
+    server: 'https://kubernetes.default.svc'
+  project: services
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+  source:
+    chart: ocp-subscription
+    repoURL: "" # Populated by kustomize patches in 2-services/kustomization.yaml
+    targetRevision: 1.0.0
+    helm:
+      parameters:
+      - name: metadata.name
+        value: ibm-watson-openscale-operator-subscription
+      - name: spec.channel
+        value: v1.5
+      - name: spec.installPlanApproval
+        value: Automatic
+      - name: spec.name
+        value: ibm-cpd-wos
+      - name: spec.source
+        value: ibm-operator-catalog
+      - name: spec.sourceNamespace
+        value: openshift-marketplace

--- a/0-bootstrap/single-cluster/1-infra/argocd/infraconfig.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/infraconfig.yaml
@@ -22,7 +22,7 @@ spec:
             name: "${PLATFORM}" # set to aws or vsphere,
             managed: "${MANAGED}" # set to true for ARO or ROSA
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
           registry:
             storageClassName: ocs-storagecluster-cephfs
@@ -42,3 +42,4 @@ spec:
     automated:
       prune: true
       selfHeal: true
+

--- a/0-bootstrap/single-cluster/1-infra/argocd/storage.yaml
+++ b/0-bootstrap/single-cluster/1-infra/argocd/storage.yaml
@@ -17,12 +17,12 @@ spec:
     path: storage
     helm:
       values: |
-        odf-operator:
+        ${STORAGE_CHART_NAME}:
           channel: ${CHANNEL}
           sizeGiB: 512
           storageClass: ${STORCLASS}
           argo:
-            namespace: openshift-gitops
+            namespace: ${GIT_GITOPS_NAMESPACE}
             serviceAccount: openshift-gitops-cntk-argocd-application-controller
   syncPolicy:
     automated:

--- a/scripts/infra-mod.sh
+++ b/scripts/infra-mod.sh
@@ -136,6 +136,7 @@ sed -i.bak '/namespace-openshift-storage.yaml/s/^#//g' kustomization.yaml
 sed -i.bak '/storage.yaml/s/^#//g' kustomization.yaml
 rm kustomization.yaml.bak
 # edit argocd/storage.yaml
+
 newChannel="stable-${majorVer}"
 defsc=$(oc get sc | grep default | awk '{print $1}')
 if [[ "$platform" == "aws" ]]; then
@@ -148,6 +149,14 @@ if [[ "$platform" == "aws" ]]; then
     storageClass=${defsc:-"ibmc-vpc-block-10iops-tier"}
 fi
 
+
+if echo $majorVer | grep -E '4.[6-8]' ]] ; then
+    storageChart="ocs-operator"
+elif echo $majorVer | grep -E '4.9|4.[1-9][0-9]|4.[1-9][0-9][0-9]' ]] ; then
+    storageChart="odf-operator"
+fi
+
+sed -i.bak "s#\${STORAGE_CHART_NAME}#${storageChart}#" argocd/storage.yaml
 sed -i.bak "s#\${CHANNEL}#${newChannel}#" argocd/storage.yaml
 sed -i.bak "s#\${STORCLASS}#${storageClass}#" argocd/storage.yaml
 rm argocd/storage.yaml.bak
@@ -157,12 +166,10 @@ popd
 
 pushd "${SCRIPTDIR}/.."
 
-${SCRIPTDIR}/sync-manifests.sh
+source ${SCRIPTDIR}/sync-manifests.sh
 
-git add .
-
-git commit -m "Editing infrastructure definitions"
-
-git push origin
+# git add .
+# git commit -m "Editing infrastructure definitions"
+# git push origin
 
 popd

--- a/scripts/infra-mod.sh
+++ b/scripts/infra-mod.sh
@@ -150,9 +150,9 @@ if [[ "$platform" == "aws" ]]; then
 fi
 
 
-if echo $majorVer | grep -E '4.[6-8]' ]] ; then
+if echo $majorVer | grep -E '4.[6-8]' > /dev/null ; then
     storageChart="ocs-operator"
-elif echo $majorVer | grep -E '4.9|4.[1-9][0-9]|4.[1-9][0-9][0-9]' ]] ; then
+elif echo $majorVer | grep -E '4.9|4.[1-9][0-9]|4.[1-9][0-9][0-9]' > /dev/null ; then
     storageChart="odf-operator"
 fi
 

--- a/scripts/sync-manifests.sh
+++ b/scripts/sync-manifests.sh
@@ -13,9 +13,12 @@ do
 
     for CLUSTER in 1-shared-cluster/cluster-1-cicd-dev-stage-prod 1-shared-cluster/cluster-n-prod 2-isolated-cluster/cluster-1-cicd-dev-stage 2-isolated-cluster/cluster-n-prod 3-multi-cluster/cluster-1-cicd 3-multi-cluster/cluster-2-dev 3-multi-cluster/cluster-3-stage 3-multi-cluster/cluster-n-prod
     do
-        rm -r 0-bootstrap/others/${CLUSTER}/${LAYER}/argocd
-        cp -a 0-bootstrap/single-cluster/${LAYER}/{argocd,${LAYER}.yaml,kustomization.yaml} 0-bootstrap/others/${CLUSTER}/${LAYER}/
-
+        test -e 0-bootstrap/others/${CLUSTER}/${LAYER}/argocd && {
+            rm -r 0-bootstrap/others/${CLUSTER}/${LAYER}/argocd
+        }
+        test -e 0-bootstrap/single-cluster && test -e 0-bootstrap/others && {
+            cp -a 0-bootstrap/single-cluster/${LAYER}/{argocd,${LAYER}.yaml,kustomization.yaml} 0-bootstrap/others/${CLUSTER}/${LAYER}/
+        }
     done
 
 done


### PR DESCRIPTION
1. Automatically select ODF (4.9 or greater) or OCS (4.6 to 4.8)
2. Stop Automatic git push on infra-mod.sh execution
3. Improved path detection on sync-manifests.sh