### PR TITLE
updating ibm ace operator to v4.2

### DIFF
--- a/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-1-cicd-dev-stage-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/1-shared-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-1-cicd-dev-stage/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/2-isolated-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-1-cicd/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-2-dev/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-3-stage/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/others/3-multi-cluster/cluster-n-prod/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/doc/scenarios/apic-multi-cluster/gateway-analytics-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/doc/scenarios/apic-multi-cluster/gateway-analytics-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog

--- a/doc/scenarios/apic-multi-cluster/management-portal-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/doc/scenarios/apic-multi-cluster/management-portal-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -23,7 +23,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v4.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog


### PR DESCRIPTION
Updating ibm ace operator channel from v1.5 to v4.2. Channel v4.2 supports OpenShift 4.6, 4.7, 4.8, 4.10. Most recent status is v7.1 that only supports 4.10. 