### PR TITLE
Update ibm-ace-operator.yaml

### DIFF
--- a/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
+++ b/0-bootstrap/single-cluster/2-services/argocd/operators/ibm-ace-operator.yaml
@@ -24,7 +24,7 @@ spec:
             ibmace:
               name: ibm-ace
               subscription:
-                channel: v1.5
+                channel: v7.2
                 installPlanApproval: Automatic
                 name: ibm-appconnect
                 source: ibm-operator-catalog


### PR DESCRIPTION
Updated ACE Operator version to latest. The preexisting version of v1.5 breaks the operator deployment.